### PR TITLE
fixed run-time error with deprecated jade syntax caused by older express version, and added menu style

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -3,7 +3,7 @@ extends layout
 block body
   div
     h2 My Blog
-    ul
+    ul.menu
       li
         a(href='/') Home
       li

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,4 +1,3 @@
-!!!
 html(ng-app="myApp")
   head
     meta(charset='utf8')


### PR DESCRIPTION
The following is the result of a fresh pull:
![jade-error](https://f.cloud.github.com/assets/3515965/1815410/dd4679a6-6f17-11e3-9d40-fd6d5042cdbe.png)
